### PR TITLE
drop django < 1.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache: pip
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -15,9 +14,6 @@ env:
   - DJANGO='https://github.com/django/django/archive/master.tar.gz'
   - DJANGO='django>=2.0,<2.1.0'
   - DJANGO='django>=1.11.0,<1.12.0'
-  - DJANGO='django>=1.10.0,<1.11.0'
-  - DJANGO='django>=1.9.0,<1.10.0'
-  - DJANGO='django>=1.8.0,<1.9.0'
 
 install:
   - travis_retry pip install --upgrade pip setuptools wheel
@@ -36,24 +32,8 @@ matrix:
       env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
     - python: "2.7"
       env: DJANGO='django>=2.0,<2.1.0'
-    - python: "3.3"
-      env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
-    - python: "3.3"
-      env: DJANGO='django>=2.0,<2.1.0'
-    - python: "3.3"
-      env: DJANGO='django>=1.11.0,<1.12.0'
-    - python: "3.3"
-      env: DJANGO='django>=1.10.0,<1.11.0'
-    - python: "3.3"
-      env: DJANGO='django>=1.9.0,<1.10.0'
     - python: "3.4"
       env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
-    - python: "3.6"
-      env: DJANGO='django>=1.10.0,<1.11.0'
-    - python: "3.6"
-      env: DJANGO='django>=1.9.0,<1.10.0'
-    - python: "3.6"
-      env: DJANGO='django>=1.8.0,<1.9.0'
 
   allow_failures:
     - env: DJANGO='https://github.com/django/django/archive/master.tar.gz'

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+=== 0.2 (unreleased) ===
+- Drop official support for django < 1.11 and python 3.2-3.3
+
+
 === 0.1.9 (10-09-2017) ===
 - Changed SentNotification.error_message to a TextField to fix issues when message is longer than 255 characters
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ A Django messaging library that features:
 - Maintains a history of messaging sending attempts and can view these messages
 - Disabling notifications per user
 
+# Python/Django Support
+
+We try to make herald support all versions of django that django supports + all versions in between. 
+
+For python, herald supports all versions of python that the above versions of django support.
+
+So as of herald v0.2 we support django 1.11 and 2.0, and python 2.7, 3.4, 3.5, and 3.6.
+
+## What version of herald do I need if I have django x and python x?
+
+If the django/python version combination has a `---` in the table, it is not guaranteed to be supported.
+
+|                   | py 2.7   | py 3.3   | py 3.4   | py 3.5   | py 3.6   |
+|:-----------------:|:--------:|:--------:|:--------:|:--------:|:--------:|
+| **dj 1.8**        | <0.2     | <0.2     | <0.2     | <0.2     | ---      |
+| **dj 1.9 - 1.10** | <0.2     | ---      | <0.2     | <0.2     | ---      |
+| **dj 1.11**       | \>=0.1.5 | ---      | \>=0.1.5 | \>=0.1.5 | \>=0.1.5 |
+| **dj 2.0**        | ---      | ---      | \>=0.1.5 | \>=0.1.5 | \>=0.1.5 |
+
+
 # Installation
 
 1. `pip install django-herald`

--- a/herald/__init__.py
+++ b/herald/__init__.py
@@ -1,7 +1,7 @@
 """
 Notification classes. Used for sending texts and emails
 """
-__version__ = '0.1.9'
+__version__ = '0.2'
 
 default_app_config = 'herald.apps.HeraldConfig'
 

--- a/herald/admin.py
+++ b/herald/admin.py
@@ -9,13 +9,7 @@ from django.contrib import admin, messages
 from django.contrib.admin.options import csrf_protect_m
 from django.contrib.admin.utils import unquote
 from django.utils.safestring import mark_safe
-
-try:
-    # django >= 1.10
-    from django.urls import reverse
-except ImportError:
-    # django <= 1.9
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from .models import SentNotification, Notification
 

--- a/herald/contrib/auth/notifications.py
+++ b/herald/contrib/auth/notifications.py
@@ -8,16 +8,10 @@ from django.contrib.sites.models import Site
 from django.template import loader
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
+from django.urls import reverse
 
-try:
-    # django >= 1.10
-    from django.urls import reverse
-except ImportError:
-    # django <= 1.9
-    from django.core.urlresolvers import reverse
-
-from herald import registry
-from herald.base import EmailNotification
+from ... import registry
+from ...base import EmailNotification
 
 
 class PasswordResetEmail(EmailNotification):

--- a/herald/views.py
+++ b/herald/views.py
@@ -1,8 +1,6 @@
 """
 Views for testing notifications. Should not be present in production
 """
-import inspect
-
 
 from django.http import HttpResponse
 from django.views.generic import TemplateView, View

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -27,11 +27,6 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
 ]
 
-if django.VERSION < (1, 10):
-    MIDDLEWARE_CLASSES = MIDDLEWARE + [
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    ]
-
 SITE_ID = 1
 
 ROOT_URLCONF = 'tests.urls'

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,13 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase, Client
 from django.utils import timezone
-
-try:
-    # django >= 1.10
-    from django.urls import reverse
-except ImportError:
-    # django <= 1.9
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from mock import patch
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 
 from herald import registry
 from herald.base import EmailNotification
-from herald.models import Notification
 
 
 class InitTests(TestCase):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,4 +1,3 @@
-import django
 from django.core.management import call_command
 from django.test import TestCase
 
@@ -8,10 +7,5 @@ from mock import patch
 class MigrationTests(TestCase):
     def test_no_migrations_created(self):
         with patch('sys.exit') as exit_mocked:
-            if django.VERSION < (1, 10):
-                # django < 1.10 uses an "exit" param that works the opposite from django > 1.10's check param
-                call_command('makemigrations', 'herald', dry_run=True, exit=True, verbosity=0)
-                exit_mocked.assert_called_with(1)
-            else:
-                call_command('makemigrations', 'herald', dry_run=True, check=True, verbosity=0)
-                exit_mocked.assert_not_called()
+            call_command('makemigrations', 'herald', dry_run=True, check=True, verbosity=0)
+            exit_mocked.assert_not_called()

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
 envlist =
-       {py27,py32,py33,py34,py35}-django18,
-       {py27,py34,py35}-django{19,110},
        {py27,py34,py35,py36}-django111,
        {py34,py35,py36}-django20,
        {py35,py36}-django-latest
@@ -10,8 +8,6 @@ envlist =
 [testenv]
 basepython =
              py27: python2.7
-             py32: python3.2
-             py33: python3.3
              py34: python3.4
              py35: python3.5
              py36: python3.6
@@ -19,9 +15,6 @@ basepython =
 
 commands = ./runtests.py
 deps =
-    django18: django>=1.8.0,<1.9.0
-    django19: django>=1.9.0,<1.10.0
-    django110: django>=1.10.0,<1.11.0
     django111: django>=1.11.0,<1.12.0
     django20: django>=2.0,<2.1.0
     django-latest: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
It's time to drop support for all versions of django below 1.11 since 1.11 is now the oldest version still supported by django. Which also means python 3.2 and 3.3 are no longer supported.