### PR TITLE
pin auth dependency in 0003 migration to prevent migration conflicts …

### DIFF
--- a/herald/migrations/0003_auto_20170830_1617.py
+++ b/herald/migrations/0003_auto_20170830_1617.py
@@ -9,7 +9,7 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('auth', '__latest__'),
+        ('auth', '0008_alter_user_username_max_length'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('herald', '0002_sentnotification_attachments'),
     ]


### PR DESCRIPTION
…when upgrading to a Django version that includes new auth migrations