### PR TITLE
Added autocomplete_fields to admin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+=== TBD (TBD) ===
+- Added auto-complete for user in admin
+
 === 0.2.1 (06-23-2019) ===
 - Fix bug that could occur sometimes in herald.contrib.auth when reversing the password reset url
 - Add feature to automatically delete old notifications after configured period of time

--- a/herald/admin.py
+++ b/herald/admin.py
@@ -25,6 +25,7 @@ class SentNotificationAdmin(admin.ModelAdmin):
     date_hierarchy = 'date_sent'
     readonly_fields = ('resend', )
     search_fields = ('recipients', 'subject', 'text_content', 'html_content', 'sent_from')
+    autocomplete_fields = ('user', )
 
     def resend(self, obj):
         """


### PR DESCRIPTION
The `user` field on `SentNotifications` makes the admin slow if you have 1000s of users.  Added `autocomplete_fields`.  This field would be ignored by Django < 2.0.

Caveat is that the `User` admin has to have `search_fields` defined for autocomplete to work. By default, `django.contrib.auth.admin.UserAdmin` has `search_fields = ('username', 'first_name', 'last_name', 'email')` so that shouldn't be a problem unless someone has created a custom admin for `User` and did not define `search_fields` in it.