### PR TITLE
"Resend" action from admin always shows failure message

### DIFF
--- a/herald/models.py
+++ b/herald/models.py
@@ -58,7 +58,7 @@ class SentNotification(models.Model):
         """
 
         notification_class = import_string(self.notification_class)
-        notification_class.resend(self)
+        return notification_class.resend(self)
 
     def get_extra_data(self):
         """


### PR DESCRIPTION
The `resend` action in the admin expects that `SentNotificationAdmin.resend()` method returns a boolean. Added a missing return.