### PR TITLE
update how 'delnotifys' command works with different args options

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ python manage.py delnotifs
 ```
 
 However, you can also pass arguments for `start` or `end` dates. `end` is up to, but not including that date.
+- if only `end` is specified, delete anything sent before the end date.
+- if only `start` is specified, delete anything sent since the start date.
+- if both `start` and `end` are specified, delete anything sent in between, not including the end date.
 
 ```bash
 python manage.py delnotifs --start='2016-01-01' --end='2016-01-10'

--- a/herald/management/commands/delnotifs.py
+++ b/herald/management/commands/delnotifs.py
@@ -18,10 +18,18 @@ class Command(BaseCommand):
         parser.add_argument('--end', help="up to this date, format YYYY-MM-DD", type=valid_date)
 
     def handle(self, *args, **options):
-        today = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        start_date = options['start'] if options['start'] else today
-        end_date = options['end'] if options['end'] else today + datetime.timedelta(days=1)
-        qs = SentNotification.objects.filter(date_sent__range=[start_date, end_date])
+        start_date = options.get('start')
+        end_date = options.get('end')
+
+        if not start_date and not end_date:
+            qs = SentNotification.objects.filter(date_sent__date=timezone.localdate())
+        else:
+            today = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
+            date_filters = { "date_sent__lt": end_date or (today + datetime.timedelta(days=1)) }
+            if start_date:
+                date_filters["date_sent__gte"] = start_date
+            qs = SentNotification.objects.filter(**date_filters)
+        
         present_notifications = qs.count()
         deleted_notifications = qs.delete()
         deleted_num = deleted_notifications[0] if deleted_notifications is not None else present_notifications

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -17,81 +17,65 @@ MSG = 'Successfully deleted {num} notification(s)'
 NOTIFICATION_CLASS = 'tests.notifications.MyNotification'
 
 
-class DeleteNotificationNoArgs(TestCase):
+class DeleteNotification(TestCase):
+    out = StringIO()
+    today = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
+    def setUp(self):
+        SentNotification(
+            notification_class=NOTIFICATION_CLASS,
+            date_sent=timezone.now() - timedelta(days=3)
+        ).save()
+        SentNotification(
+            notification_class=NOTIFICATION_CLASS,
+            date_sent=timezone.now() - timedelta(days=2)
+        ).save()
+        SentNotification(
+            notification_class=NOTIFICATION_CLASS,
+            date_sent=timezone.now() - timedelta(days=1)
+        ).save()
+        SentNotification(
+            notification_class=NOTIFICATION_CLASS,
+            date_sent=timezone.now()
+        ).save()
+        SentNotification(
+            notification_class=NOTIFICATION_CLASS,
+            date_sent=timezone.now()
+        ).save()
+    
     def test_date_validator(self):
         self.assertEqual(
             valid_date('2017-01-01'),
             datetime(2017,1,1)
         )
 
-    def test_delete_today(self):
-        SentNotification(
-            notification_class=NOTIFICATION_CLASS,
-            date_sent=timezone.now()
-        ).save()
-        SentNotification(
-            notification_class=NOTIFICATION_CLASS,
-            date_sent=timezone.now()+timedelta(days=1)
-        ).save()
-        out = StringIO()
-        call_command('delnotifs', stdout=out)
-        self.assertIn(MSG.format(num=1), out.getvalue())
+    def test_delete_without_arg(self):
+        call_command('delnotifs', stdout=self.out)
+        self.assertIn(MSG.format(num=2), self.out.getvalue())
+    
+    def test_delete_start_end_range_args(self):
+        two_days_ago = self.today - timedelta(days=2)
+        call_command('delnotifs', stdout=self.out, start=str(two_days_ago), end=str(self.today))
+        self.assertIn(MSG.format(num=2), self.out.getvalue())
 
-    def test_do_not_delete_tomorrow(self):
-        SentNotification(
-            notification_class=NOTIFICATION_CLASS,
-            date_sent=timezone.now()+timedelta(days=1)
-        ).save()
-        out = StringIO()
-        call_command('delnotifs', stdout=out)
-        self.assertIn(MSG.format(num=0), out.getvalue())
-
-    def test_do_not_delete_yesterday(self):
-        SentNotification(
-            notification_class=NOTIFICATION_CLASS,
-            date_sent=timezone.now() - timedelta(days=1)
-        ).save()
-        out = StringIO()
-        call_command('delnotifs', stdout=out)
-        self.assertIn(MSG.format(num=0), out.getvalue())
-
-
-class DeleteNotificationArgs(TestCase):
-
-    def test_delete_today_start_arg(self):
-        SentNotification(
-            notification_class=NOTIFICATION_CLASS,
-            date_sent=timezone.now()
-        ).save()
-        SentNotification(
-            notification_class=NOTIFICATION_CLASS,
-            date_sent=timezone.now()+timedelta(days=1)
-        ).save()
-        out = StringIO()
-        today = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        call_command('delnotifs', stdout=out, start=str(today))
-        self.assertIn(MSG.format(num=1), out.getvalue())
-
-    def test_do_not_delete_tomorrow_end_arg(self):
-        SentNotification(
-            notification_class=NOTIFICATION_CLASS,
-            date_sent=timezone.now()+timedelta(days=1)
-        ).save()
-        out = StringIO()
-        two_days_later = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=2)
-        call_command('delnotifs', stdout=out, end=str(two_days_later))
-        self.assertIn(MSG.format(num=1), out.getvalue())
+    def test_start_date_only_arg(self):
+        two_days_ago = self.today - timedelta(days=2)
+        call_command('delnotifs', stdout=self.out, start=str(two_days_ago))
+        self.assertIn(MSG.format(num=4), self.out.getvalue())
+    
+    def test_end_date_only_arg(self):
+        one_days_ago = self.today - timedelta(days=1)
+        call_command('delnotifs', stdout=self.out, end=str(one_days_ago))
+        self.assertIn(MSG.format(num=2), self.out.getvalue())
 
     def test_do_accept_bad_args(self):
         SentNotification(
             notification_class=NOTIFICATION_CLASS,
-            date_sent=timezone.now() - timedelta(days=1)
+            date_sent=self.today - timedelta(days=1)
         ).save()
-        out = StringIO()
 
         with self.assertRaises(ValidationError):
-            call_command('delnotifs', stdout=out, start='blargh')
+            call_command('delnotifs', stdout=self.out, start='blargh')
 
         with self.assertRaises(ValidationError):
-            call_command('delnotifs', stdout=out, start='01-01-2016')
+            call_command('delnotifs', stdout=self.out, start='01-01-2016')


### PR DESCRIPTION
This PR updates how `delnotifys` command works. The current behavior doesn't make much sense since `date_sent` field can never be a future datetime. Changes include:

- if only `end` is specified, delete anything sent before the end date.
- if only `start` is specified, delete anything sent since the start date.
- if both `start` and `end` are specified, delete anything sent in between, not including the end date.

test cases are updated to reflect the changes.

README is updated to include more detailed instruction.