### PR TITLE
Configurable raise exception on missing templates

### DIFF
--- a/herald/base.py
+++ b/herald/base.py
@@ -187,7 +187,7 @@ class NotificationBase(object):
         except TemplateDoesNotExist:
             content = None
 
-            if settings.DEBUG:
+            if settings.DEBUG or getattr(settings, 'HERALD_RAISE_MISSING_TEMPLATES', True):
                 raise
 
         return content


### PR DESCRIPTION
Currently an exception is only raised if debug is `True`, however the web app may be built as a container in CD, resulting in the process of generating the templates may be different to local development (we hit this and ended up sending blank emails to all our users as the template was not installed correctly during CD but worked fine locally).

This PR adds an additional setting (`HERALD_RAISE_MISSING_TEMPLATES`) - it defaults to `True` which I think may be the safer default.

Cheers!