### PR TITLE
Update code for django==4.0.0

### DIFF
--- a/herald/admin.py
+++ b/herald/admin.py
@@ -4,7 +4,10 @@ Admin for notifications
 
 from functools import update_wrapper
 
-from django.urls import re_path
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 from django.contrib import admin, messages
 from django.contrib.admin.options import csrf_protect_m
 from django.contrib.admin.utils import unquote
@@ -59,7 +62,7 @@ class SentNotificationAdmin(admin.ModelAdmin):
         info = opts.app_label, opts.model_name
 
         return [
-            re_path(r'^(.+)/resend/$', wrap(self.resend_view), name='%s_%s_resend' % info),
+            url(r'^(.+)/resend/$', wrap(self.resend_view), name='%s_%s_resend' % info),
         ] + urls
 
     @csrf_protect_m

--- a/herald/admin.py
+++ b/herald/admin.py
@@ -4,7 +4,7 @@ Admin for notifications
 
 from functools import update_wrapper
 
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin, messages
 from django.contrib.admin.options import csrf_protect_m
 from django.contrib.admin.utils import unquote
@@ -59,7 +59,7 @@ class SentNotificationAdmin(admin.ModelAdmin):
         info = opts.app_label, opts.model_name
 
         return [
-            url(r'^(.+)/resend/$', wrap(self.resend_view), name='%s_%s_resend' % info),
+            re_path(r'^(.+)/resend/$', wrap(self.resend_view), name='%s_%s_resend' % info),
         ] + urls
 
     @csrf_protect_m

--- a/herald/contrib/auth/notifications.py
+++ b/herald/contrib/auth/notifications.py
@@ -6,7 +6,12 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
 from django.template import loader
-from django.utils.encoding import force_bytes, force_str
+from django.utils.encoding import force_bytes
+try:
+    from django.utils.encoding import force_str as force_text
+except ImportError:
+    from django.utils.encoding import force_text
+
 from django.utils.http import urlsafe_base64_encode
 from django.urls import reverse
 
@@ -45,7 +50,7 @@ class PasswordResetEmail(EmailNotification):
             self.domain = current_site.domain
 
         protocol = 'https' if self.use_https else 'http'
-        uid = force_str(urlsafe_base64_encode(force_bytes(self.user.pk)))
+        uid = force_text(urlsafe_base64_encode(force_bytes(self.user.pk)))
         token = self.token_generator.make_token(self.user)
 
         context.update({

--- a/herald/contrib/auth/notifications.py
+++ b/herald/contrib/auth/notifications.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
 from django.template import loader
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_encode
 from django.urls import reverse
 
@@ -45,7 +45,7 @@ class PasswordResetEmail(EmailNotification):
             self.domain = current_site.domain
 
         protocol = 'https' if self.use_https else 'http'
-        uid = force_text(urlsafe_base64_encode(force_bytes(self.user.pk)))
+        uid = force_str(urlsafe_base64_encode(force_bytes(self.user.pk)))
         token = self.token_generator.make_token(self.user)
 
         context.update({

--- a/herald/urls.py
+++ b/herald/urls.py
@@ -2,11 +2,14 @@
 Urls for herald app
 """
 
-from django.urls import re_path
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from .views import TestNotificationList, TestNotification
 
 urlpatterns = [
-    re_path(r'^$', TestNotificationList.as_view(), name='herald_preview_list'),
-    re_path(r'^(?P<index>\d+)/(?P<type>[\w\-]+)/$', TestNotification.as_view(), name='herald_preview'),
+    url(r'^$', TestNotificationList.as_view(), name='herald_preview_list'),
+    url(r'^(?P<index>\d+)/(?P<type>[\w\-]+)/$', TestNotification.as_view(), name='herald_preview'),
 ]

--- a/herald/urls.py
+++ b/herald/urls.py
@@ -2,11 +2,11 @@
 Urls for herald app
 """
 
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import TestNotificationList, TestNotification
 
 urlpatterns = [
-    url(r'^$', TestNotificationList.as_view(), name='herald_preview_list'),
-    url(r'^(?P<index>\d+)/(?P<type>[\w\-]+)/$', TestNotification.as_view(), name='herald_preview'),
+    re_path(r'^$', TestNotificationList.as_view(), name='herald_preview_list'),
+    re_path(r'^(?P<index>\d+)/(?P<type>[\w\-]+)/$', TestNotification.as_view(), name='herald_preview'),
 ]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,11 +3,15 @@ from __future__ import unicode_literals
 
 from django.contrib import admin
 from django.contrib.auth import urls as auth_urls
-from django.urls import re_path, include
+from django.urls import include
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 
 urlpatterns = [
-    re_path(r'^admin/', admin.site.urls),
-    re_path('^', include(auth_urls)),
-    re_path(r'^herald/', include('herald.urls')),
+    url(r'^admin/', admin.site.urls),
+    url('^', include(auth_urls)),
+    url(r'^herald/', include('herald.urls')),
 ]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,11 +3,11 @@ from __future__ import unicode_literals
 
 from django.contrib import admin
 from django.contrib.auth import urls as auth_urls
-from django.conf.urls import url, include
+from django.urls import re_path, include
 
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url('^', include(auth_urls)),
-    url(r'^herald/', include('herald.urls')),
+    re_path(r'^admin/', admin.site.urls),
+    re_path('^', include(auth_urls)),
+    re_path(r'^herald/', include('herald.urls')),
 ]


### PR DESCRIPTION
The current version of django-herald doesn't work with django 4. This PR aims to update `herald` to work with django 4 while keeping backwards compatibility.

The app `herald.contrib.auth` wouldn't work as of now due to the issue https://github.com/worthwhile/django-herald/issues/78